### PR TITLE
hamamatsu: add support for NDPI images > 4 GB

### DIFF
--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -165,18 +165,6 @@ static uint32_t get_value_size(uint16_t type, uint64_t *count) {
   }
 }
 
-// Re-add implied high-order bits to a 32-bit offset.
-// Heuristic: maximize high-order bits while keeping the offset below diroff.
-static uint64_t fix_offset_ndpi(uint64_t diroff, uint64_t offset) {
-  uint64_t result = (diroff & ~(uint64_t) UINT32_MAX) | (offset & UINT32_MAX);
-  if (result >= diroff) {
-    // ensure result doesn't wrap around
-    result = MIN(result - UINT32_MAX - 1, result);
-  }
-  //g_debug("diroff %"PRIx64": %"PRIx64" -> %"PRIx64, diroff, offset, result);
-  return result;
-}
-
 #define ALLOC_VALUES_OR_FAIL(OUT, TYPE, COUNT) do {			\
     OUT = g_try_new(TYPE, COUNT);					\
     if (!OUT) {								\
@@ -389,7 +377,6 @@ static void tiff_item_destroy(gpointer data) {
 
 static struct tiff_directory *read_directory(struct _openslide_file *f,
                                              uint64_t *diroff,
-                                             struct tiff_directory *first_dir,
                                              GHashTable *loop_detector,
                                              bool bigtiff,
                                              bool ndpi,
@@ -476,14 +463,50 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
     }
 
     // read in the value/offset
-    uint8_t value[bigtiff ? 8 : 4];
-    if (!_openslide_fread_exact(f, value, sizeof(value), err)) {
+    uint8_t value[(bigtiff || ndpi) ? 8 : 4];
+    size_t read_size = (bigtiff ? 8 : 4);
+
+    if (!_openslide_fread_exact(f, value, read_size, err)) {
       g_prefix_error(err, "Cannot read value/offset: ");
       return NULL;
     }
 
+    bool is_value = (value_size * count <= read_size);
+
+    // in ndpi files all values/offsets have a 4 byte extension at the end
+    // of the IFD
+    // append this to the current value/offset
+    if (ndpi) {
+      // seek to value/offset extension
+      if (!_openslide_fseek(f, off + (12L * dircount) + (4L * n) + 10L,
+                            SEEK_SET, err)) {
+        g_prefix_error(err, "Cannot seek to value/offset extension: ");
+        return NULL;
+      }
+
+      // read in the value/offset extension
+      if (!_openslide_fread_exact(f, value + 4, 4, err)) {
+        g_prefix_error(err, "Cannot read value/offset extension: ");
+        return NULL;
+      }
+
+      // if the value/offset contains the value and the extension is
+      // nonzero, update the value size and item type
+      if (is_value &&
+          (value[4] > 0 || value[5] > 0 || value[6] > 0 || value[7] > 0)) {
+        value_size = 8;
+        item->type = TIFF_LONG8;
+      }
+
+      // seek back to the tag's position in the IFD
+      if (!_openslide_fseek(f, off + (12L * (n + 1)) + 2L, SEEK_SET, err)) {
+        g_prefix_error(err, "Seeking back to IFD failed: ");
+        return NULL;
+      }
+    }
+
     // does value/offset contain the value?
-    if (value_size * count <= sizeof(value)) {
+    if (is_value) {
       // yes
       fix_byte_order(value, value_size, count, big_endian);
       if (!set_item_values(item, value, err)) {
@@ -492,7 +515,7 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
 
     } else {
       // no; store offset
-      if (bigtiff) {
+      if (bigtiff || ndpi) {
         memcpy(&item->offset, value, 8);
         fix_byte_order(&item->offset, sizeof(item->offset), 1, big_endian);
       } else {
@@ -500,19 +523,6 @@ static struct tiff_directory *read_directory(struct _openslide_file *f,
         memcpy(&off32, value, 4);
         fix_byte_order(&off32, sizeof(off32), 1, big_endian);
         item->offset = off32;
-      }
-
-      if (ndpi) {
-        // heuristically set high-order bits of offset
-        // if this tag has the same offset in the first IFD, reuse that value
-        struct tiff_item *first_dir_item = NULL;
-        if (first_dir) {
-          first_dir_item = g_hash_table_lookup(first_dir->items,
-                                               GINT_TO_POINTER(tag));
-        }
-        if (!first_dir_item || first_dir_item->offset != item->offset) {
-          item->offset = fix_offset_ndpi(off, item->offset);
-        }
       }
     }
   }
@@ -607,7 +617,6 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   if (!bigtiff && diroff != 0) {
     uint64_t trial_diroff = diroff;
     struct tiff_directory *d = read_directory(f, &trial_diroff,
-                                              NULL,
                                               loop_detector,
                                               bigtiff, true, big_endian,
                                               NULL);
@@ -641,7 +650,6 @@ struct _openslide_tifflike *_openslide_tifflike_create(const char *filename,
   while (diroff != 0) {
     // read a directory
     struct tiff_directory *d = read_directory(f, &diroff,
-                                              first_dir,
                                               loop_detector,
                                               bigtiff, tl->ndpi, big_endian,
                                               err);
@@ -937,16 +945,6 @@ bool _openslide_tifflike_is_tiled(struct _openslide_tifflike *tl,
                                   int64_t dir) {
   return _openslide_tifflike_get_value_count(tl, dir, TIFFTAG_TILEWIDTH) &&
          _openslide_tifflike_get_value_count(tl, dir, TIFFTAG_TILELENGTH);
-}
-
-uint64_t _openslide_tifflike_uint_fix_offset_ndpi(struct _openslide_tifflike *tl,
-                                                  int64_t dir, uint64_t offset) {
-  g_assert(dir >= 0 && dir < tl->directories->len);
-  if (!tl->ndpi) {
-    return offset;
-  }
-  struct tiff_directory *d = tl->directories->pdata[dir];
-  return fix_offset_ndpi(d->offset, offset);
 }
 
 static const char *store_string_property(struct _openslide_tifflike *tl,

--- a/src/openslide-decode-tifflike.h
+++ b/src/openslide-decode-tifflike.h
@@ -74,11 +74,6 @@ const uint64_t *_openslide_tifflike_get_uints(struct _openslide_tifflike *tl,
                                               int64_t dir, int32_t tag,
                                               GError **err);
 
-// if the file was detected as NDPI, heuristically add high-order bits to
-// the specified offset
-uint64_t _openslide_tifflike_uint_fix_offset_ndpi(struct _openslide_tifflike *tl,
-                                                  int64_t dir, uint64_t offset);
-
 // TIFF_SBYTE, TIFF_SSHORT, TIFF_SLONG
 int64_t _openslide_tifflike_get_sint(struct _openslide_tifflike *tl,
                                      int64_t dir, int32_t tag,

--- a/src/openslide-vendor-hamamatsu.c
+++ b/src/openslide-vendor-hamamatsu.c
@@ -79,7 +79,8 @@ static const int KEY_FILE_MAX_SIZE = 64 << 10;
 #define NDPI_XOFFSET 65422
 #define NDPI_YOFFSET 65423
 #define NDPI_FOCAL_PLANE 65424
-#define NDPI_MCU_STARTS 65426
+#define NDPI_MCU_STARTS_LOW_BYTES 65426
+#define NDPI_MCU_STARTS_HIGH_BYTES 65432
 #define NDPI_REFERENCE 65427
 #define NDPI_PROPERTY_MAP 65449
 #define JPEG_MAX_DIMENSION_HIGH ((JPEG_MAX_DIMENSION >> 8) & 0xff)
@@ -2119,8 +2120,6 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
     TIFF_GET_UINT_OR_RETURN(tl, dir, TIFFTAG_ROWSPERSTRIP, rows_per_strip, false);
     TIFF_GET_UINT_OR_RETURN(tl, dir, TIFFTAG_STRIPOFFSETS, start_in_file, false);
     TIFF_GET_UINT_OR_RETURN(tl, dir, TIFFTAG_STRIPBYTECOUNTS, num_bytes, false);
-    start_in_file = _openslide_tifflike_uint_fix_offset_ndpi(tl, dir,
-                                                             start_in_file);
 
     double lens =
       _openslide_tifflike_get_float(tl, dir, NDPI_SOURCELENS, &tmp_err);
@@ -2227,17 +2226,31 @@ static bool hamamatsu_ndpi_open(openslide_t *osr, const char *filename,
       // read MCU starts, if this directory is tiled
       if (jp->tile_count > 1) {
         int64_t mcu_start_count =
-          _openslide_tifflike_get_value_count(tl, dir, NDPI_MCU_STARTS);
+          _openslide_tifflike_get_value_count(tl, dir,
+                                              NDPI_MCU_STARTS_LOW_BYTES);
 
         if (mcu_start_count == jp->tile_count) {
           //g_debug("loading MCU starts for directory %"PRId64, dir);
-          const uint64_t *unreliable_mcu_starts =
-            _openslide_tifflike_get_uints(tl, dir, NDPI_MCU_STARTS, NULL);
-          if (unreliable_mcu_starts) {
+          const uint64_t *unreliable_mcu_starts_low_bytes =
+            _openslide_tifflike_get_uints(tl, dir, NDPI_MCU_STARTS_LOW_BYTES,
+                                          NULL);
+          const uint64_t *unreliable_mcu_starts_high_bytes =
+            _openslide_tifflike_get_uints(tl, dir, NDPI_MCU_STARTS_HIGH_BYTES,
+                                          NULL);
+          if (unreliable_mcu_starts_low_bytes &&
+              unreliable_mcu_starts_high_bytes) {
             jp->unreliable_mcu_starts = g_new(int64_t, mcu_start_count);
             for (int64_t tile = 0; tile < mcu_start_count; tile++) {
               jp->unreliable_mcu_starts[tile] =
-                jp->start_in_file + unreliable_mcu_starts[tile];
+                jp->start_in_file + unreliable_mcu_starts_low_bytes[tile] +
+                (unreliable_mcu_starts_high_bytes[tile] << 32);
+              //g_debug("mcu start at %"PRId64, jp->unreliable_mcu_starts[tile] + (unreliable_mcu_starts_high_bytes[tile] << 32));
+            }
+          } else if (unreliable_mcu_starts_low_bytes) {
+            jp->unreliable_mcu_starts = g_new(int64_t, mcu_start_count);
+            for (int64_t tile = 0; tile < mcu_start_count; tile++) {
+              jp->unreliable_mcu_starts[tile] =
+                jp->start_in_file + unreliable_mcu_starts_low_bytes[tile];
               //g_debug("mcu start at %"PRId64, jp->unreliable_mcu_starts[tile]);
             }
           } else {


### PR DESCRIPTION
Addresses issue #174 (and possibly others), regarding the reading of large NDPI files.  This issue stems from the fact that classical TIFF (and by extension, NDPI) images only support up to 32 bit values for tagged metadata.  However, due to the nature of whole slide image data, it isn't uncommon for the size of an NDPI to exceed the 32 bit range. This means that key metadata, such as the byte positions of image layers or their size in bytes, may be too large to store in a traditional TIFF IFD entry.

Currently OpenSlide relies on heuristics to determine the high bits of 64 bit addresses, which fail in some cases.  However, this is unnecessary, as NDPI actually stores the high bits of the offset/value of each tag in 4 byte blocks immediately after the end of the IFD.

This fix modifies openslide-decode-tifflike.c to append these extra 4 bytes to each IFD entry's value/offset and, if necessary, modifies its type to LONG8.

This fix also modifies openslide-vendor-hamamatsu.c to construct correct restart marker addresses.  Currently only the values in TIFF tag 65426 are used, which are only the lower 32 bits of each address.  High bits are stored in TIFF tag 65432, so these are now appended before mcu_starts are calculated.